### PR TITLE
0.3.4 remote spurious variable declaration in _helpers.tpl

### DIFF
--- a/helm/alfresco-identity-service/Chart.yaml
+++ b/helm/alfresco-identity-service/Chart.yaml
@@ -1,5 +1,5 @@
 name: alfresco-identity-service
-version: 0.3.3
+version: 0.3.5
 description: The Alfresco Identity Service provides a Single Sign On experience for the Alfresco Digital Business Platform (DBP).
 keywords:
   - alfresco

--- a/helm/alfresco-identity-service/templates/_helpers.tpl
+++ b/helm/alfresco-identity-service/templates/_helpers.tpl
@@ -9,6 +9,5 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 
 {{- define "keycloak.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-keycloak" .Release.Name | trunc 20 | trimSuffix "-" -}}
 {{- end -}}


### PR DESCRIPTION
`$name` declaration looks like it had been copied and pasted from one definition to the other by mistake.

Deleted as it isn't referenced.