### PR TITLE
AUTH-148/AUTH-197: Added init container to bootstrap alfresco keycloak theme

### DIFF
--- a/helm/alfresco-identity-service/alfresco-realm.json
+++ b/helm/alfresco-identity-service/alfresco-realm.json
@@ -1091,6 +1091,7 @@
     "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';"
   },
   "smtpServer": {},
+  "loginTheme": "alfresco",
   "eventsEnabled": false,
   "eventsListeners": [
     "jboss-logging"
@@ -1240,8 +1241,24 @@
       }
     ]
   },
-  "internationalizationEnabled": false,
-  "supportedLocales": [],
+  "internationalizationEnabled": true,
+  "supportedLocales": [
+    "de",
+    "no",
+    "ru",
+    "sv",
+    "pt-BR",
+    "lt",
+    "en",
+    "it",
+    "fr",
+    "zh-CN",
+    "es",
+    "ja",
+    "ca",
+    "nl"
+  ],
+  "defaultLocale": "en",
   "authenticationFlows": [
     {
       "id": "ac4ffcd4-6547-4e1c-90ac-aa56304011fb",

--- a/helm/alfresco-identity-service/values.yaml
+++ b/helm/alfresco-identity-service/values.yaml
@@ -15,14 +15,32 @@ keycloak:
   keycloak:
     username: admin
     password: admin
+    extraInitContainers: |
+      - name: theme-provider
+        image: alfresco-keycloak-theme:0.1
+        imagePullPolicy: IfNotPresent
+        command:
+          - sh
+        args:
+          - -c
+          - |
+            echo "Copying theme..."
+            cp -R /alfresco/* /theme
+        volumeMounts:
+          - name: theme
+            mountPath: /theme    
     extraVolumes: |
       - name: realm-secret
         secret:
           secretName: realm-secret
+      - name: theme
+        emptyDir: {}    
     extraVolumeMounts: |
       - name: realm-secret
         mountPath: "/realm/"
         readOnly: true
+      - name: theme
+        mountPath: /opt/jboss/keycloak/themes/alfresco  
     extraArgs: "-Dkeycloak.import=/realm/alfresco-realm.json"
     persistence:
       dbPassword: keycloak


### PR DESCRIPTION
Added init container to bootstrap alfresco keycloak theme as per keycloak [documentation](https://github.com/helm/charts/blob/8f5c3426d9597a902d57bea378dc628ea2b91c20/stable/keycloak/README.md#providing-a-custom-theme).