### PR TITLE
AUTH-194: Re-enable Postgres in Identity Service

### DIFF
--- a/helm/alfresco-identity-service/values.yaml
+++ b/helm/alfresco-identity-service/values.yaml
@@ -43,7 +43,11 @@ keycloak:
         mountPath: /opt/jboss/keycloak/themes/alfresco  
     extraArgs: "-Dkeycloak.import=/realm/alfresco-realm.json"
     persistence:
+      deployPostgres: true
+      dbVendor: postgres
       dbPassword: keycloak
+  persistence:
+    deployPostgres: true
   postgresql:
     nameOverride: postgresql-id
     imageTag: "10.1"


### PR DESCRIPTION
   - deployPostgres by default

We need both keycloak.deployPostgres and deployPostgres to true since there are both used in different places for deploy postgres