### PR TITLE
[AUTH-209] Run all tests that touch the Identity Service to verify they still pass

### DIFF
--- a/test/saml/src/test/resources/application.properties
+++ b/test/saml/src/test/resources/application.properties
@@ -2,7 +2,8 @@ saml.username=userA
 saml.password=password
 
 keycloak.hostname=localhost
-keycloak.issuer=https://localhost/auth/realms/alfresco
+#keycloak.issuer, if set here, should be in the format of https://localhost/auth/realms/alfresco
+keycloak.issuer=
 keycloak.realm=alfresco
 
 enable.browser=false


### PR DESCRIPTION
-SAML test failure caused by a change to how failures are handled when loading a page in headless mode.
--Previously when attempting the reach a page that was not reachable a connection exception was not thrown but current URL was the unreachable URL
--Fixed by updating what the redirect hostname was set as from localhost to hostname of the test server
--This caused a change to the issuer.  Updated issuer to additionally build from hostname and realm when the expected issuer is not provided in environment or properties file