### PR TITLE
DOCS-4711 updated deployment and configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Alfresco Identity Service
 
-The Alfresco Identity Service is responsible for centralizing identity-related capabilities for other Alfresco software.
+The Identity Service allows you to configure user synchronization between a supported LDAP provider or SAML identity provider and the Identity Service for Single Sign On (SSO) capabilities in other Alfresco software.
 
 This project contains the open-source core of this service.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Alfresco Identity Service
 
-The Identity Service allows you to configure user synchronization between a supported LDAP provider or SAML identity provider and the Identity Service for Single Sign On (SSO) capabilities in other Alfresco software.
+The Identity Service allows you to configure user authentication between a supported LDAP provider or SAML identity provider and the Identity Service for Single Sign On (SSO) capabilities in other Alfresco software.
 
 This project contains the open-source core of this service.
 

--- a/README.md
+++ b/README.md
@@ -1,204 +1,21 @@
 # Alfresco Identity Service
 
-The *Alfresco Identity Service* will become the central component responsible for identity-related capabilities needed by other Alfresco software, such as managing users, groups, roles, profiles, and authentication. Currently it deals just with authentication. This project contains the open-source core of this service.
+The Alfresco Identity Service is responsible for centralizing identity-related capabilities for other Alfresco software.
 
-## Prerequisites
+This project contains the open-source core of this service.
 
-The Alfresco Identity Service deployment requires:
+## Deploying the Identity Service
+The steps in [Deploying the Identity Service](docs/deploy/is-deploy.md) detail how to deploy the Identity Service into an existing cluster. These steps use a set of default deployment options that can be customized by reading [Customizing an Identity Service deployment](docs/deploy/is-customize.md). It is recommended that you read through the customization options before starting your deployment.
 
-| Component        | Recommended version |
-| ------------- |:-------------:|
-| Docker     | 17.0.9.1 |
-| Kubernetes | 1.8.4    |
-| Kubectl    | 1.8.4    |
-| Helm       | 2.8.2    |
-| Kops       | 1.8.1    |
+## Configuring identity providers 
+Once you have deployed the Identity Service, you can configure your user synchronization with an LDAP instance or setup an existing identity provider to authenticate with the Identity Service.
 
-Any variation from these technologies and versions may affect the end result. If you do experience any issues please let us know through our [Gitter channel](https://gitter.im/Alfresco/platform-services?utm_source=share-link&utm_medium=link&utm_campaign=share-link).
+An example setup has been provided for configuring the Identity Service with a SAML 2.0 identity provider: [PingFederate](docs/config/ping-federate-example.md).
 
-### Kubernetes Cluster
+An example setup of user synchronization with an LDAP instance has been provided using [OpenLDAP](docs/config/openldap-example.md).
 
-These instructions illustrate deployment to a Kubernetes cluster on AWS.
-
-Please check the Anaxes Shipyard documentation on [running a cluster](https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/SECRETS.md).
-
-If you are deploying the Identity Service into a cluster with other Alfresco components such as Content Services and Process Services, a VPC and cluster with 5 nodes is recommended. Each node should be a m4.xlarge EC2 instance.
-
-### Helm Tiller
-
-Initialize the Helm Tiller:
-
-```bash
-helm init
-```
-
-### K8s Cluster Namespace
-
-As mentioned as part of the Anaxes Shipyard guidelines, you should deploy into a separate namespace in the cluster to avoid conflicts (create the namespace only if it does not already exist):
-
-```bash
-export DESIREDNAMESPACE=example
-kubectl create namespace $DESIREDNAMESPACE
-```
-
-This environment variable will be used in the deployment steps.
-
-## Deploying the Identity Services Chart
-
-1. In order to deploy this chart you have to deploy the [Alfresco Infrastructure chart](https://github.com/Alfresco/alfresco-infrastructure-deployment#1-deploy-the-infrastructure-charts) which will deploy the identity service too.
-
-Using the following command only the identity service and the [nginx-ingress](https://github.com/Alfresco/alfresco-infrastructure-deployment#nginx-ingress-custom-configuration) will be deployed:
-
-```bash
-
-helm repo add alfresco-stable https://kubernetes-charts.alfresco.com/stable
-
-helm install alfresco-stable/alfresco-infrastructure \
-  --set alfresco-infrastructure.activemq.enabled=false \
-  --set alfresco-infrastructure.nginx-ingress.enabled=true \
-  --set alfresco-infrastructure.alfresco-identity-service.enabled=true \
-  --namespace $DESIREDNAMESPACE
-```
-
-<!-- markdownlint-disable MD029 -->
-2. Get the release name from the previous command and set it as a variable:
-<!-- markdownlint-disable MD029 -->
-
-```bash
-export RELEASENAME=knobby-wolf
-```
-
-<!-- markdownlint-disable MD029 -->
-3. Wait for the release to get deployed (When checking status your pods should be READY 1/1):
-<!-- markdownlint-enable MD029 -->
-
-```bash
-helm status $RELEASENAME
-```
-
-<!-- markdownlint-disable MD029 -->
-4. Get local or ELB IP and set it as a variable for future use:
-<!-- markdownlint-disable MD029 -->
-
-```bash
-export ELBADDRESS=$(kubectl get services $RELEASENAME-nginx-ingress-controller --namespace=$DESIREDNAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
-```
-
-The deployment 
-
-This is deployed with the **default example realm applied** which results in default values of:
-
-| Property                      | Value                    |
-| ----------------------------- | ------------------------ |
-| Admin User Username           | `admin`                  |
-| Admin User Password           | `admin`                  |
-| Admin User Email              | `admin@app.activiti.com` |
-| Alfresco Client Redirect URIs | `http://localhost*`      |
-
-(Note that APS expects the email as the user name)
-
-#### Changing Alfresco Client redirectUris
-
-You can override the default redirectUri of `http://localhost*` for your environment with the `alfresco-identity-service.client.alfresco.redirectUris` property:
-
-```bash
-helm install alfresco-stable/alfresco-infrastructure \
-  --set alfresco-infrastructure.activemq.enabled=false \
-  --set alfresco-infrastructure.nginx-ingress.enabled=true \
-  --set alfresco-infrastructure.alfresco-identity-service.enabled=true \
-  --set alfresco-identity-service.client.alfresco.redirectUris=['\"'http://$DNSNAME*'"\'] \
-  --namespace $DESIREDNAMESPACE
-```
-
-including multiple redirectUris:
-
-```bash
-helm install alfresco-stable/alfresco-infrastructure \
-  --set alfresco-infrastructure.activemq.enabled=false \
-  --set alfresco-infrastructure.nginx-ingress.enabled=true \
-  --set alfresco-infrastructure.alfresco-identity-service.enabled=true \
-  --set alfresco-identity-service.redirectUris=['\"'http://$DNSNAME*'"\'',''\"'http://$DNSNAME1*'"\'',''\"'http://$DNSNAME2*'"\']` \
-  --namespace $DESIREDNAMESPACE
-```
-
-If you want to deploy your own realm with further customizations, see *Customizing the Realm* below.
-
-## Multiple Replicas, High Availability and Clustering
-
-For added resilience, we rely on support in the Keycloak chart for specifying multiple replicas.  To enable this you will need to deploy the identity chart with this additional setting:
-
-```bash
-
-  --set alfresco-infrastructure.alfresco-identity-service.keycloak.keycloak.replicas=3
-
-```
-
-In addition, for high availability, Keycloak supports clustering.  For more information on how to configure high availability and clustering, you can consult this additional documentation.  
-
-
-[Keycloak Stable chart Readme](https://github.com/helm/charts/tree/master/stable/keycloak#high-availability-and-clustering)
-
-
-[Keycloak Standalone Clustered configuration](https://www.keycloak.org/docs/4.5/server_installation/#standalone-clustered-configuration)
-
-
-[Keycloak Clustering](https://www.keycloak.org/docs/4.5/server_installation/#_clustering)
-
-
-**_NOTE:_** Be aware that Keycloak recommends that [sticky sessions](https://www.keycloak.org/docs/4.5/server_installation/#sticky-sessions) are used so keep that in mind if you choose to use a different ingress type than nginx.
-
-## Customizing the Realm
-
-### Customizing the Realm During Deployment
-
-1. You will need a realm file. A [sample realm](./helm/alfresco-identity-service/alfresco-realm.json) file is provided.
-
-2. Create a secret using your realm json file
-
-**_!!NOTE_** The secret name must be realm-secret, and the realm file name must not be alfresco-realm.json.
-
-```bash
-
-kubectl create secret generic realm-secret \
-  --from-file=./realm.json \
-  --namespace=$DESIREDNAMESPACE
-```
-
-
-<!-- markdownlint-disable MD029 -->
-3. Deploy the identity chart with the new settings:
-<!-- markdownlint-enable MD029 -->
-
-```bash
-
-helm repo add alfresco-stable https://kubernetes-charts.alfresco.com/stable
-
-helm install alfresco-stable/alfresco-infrastructure \
-  --set alfresco-infrastructure.activemq.enabled=false \
-  --set alfresco-infrastructure.nginx-ingress.enabled=true \
-  --set alfresco-infrastructure.alfresco-identity-service.enabled=true \
-  --set alfresco-infrastructure.alfresco-identity-service.keycloak.keycloak.extraArgs="-Dkeycloak.import=/realm/realm.json" \
-  --namespace $DESIREDNAMESPACE
-```
-
-Once Keycloak is up and running, login to the [Management Console](http://www.keycloak.org/docs/3.4/server_admin/index.html#admin-console) to configure the required realm.
-
-#### Manually
-
-1. [Add a realm](http://www.keycloak.org/docs/3.4/server_admin/index.html#_create-realm) named "Alfresco"
-
-2. [Create an OIDC client](http://www.keycloak.org/docs/3.4/server_admin/index.html#oidc-clients) named "alfresco" within the Alfresco realm
-
-3. [Create a group](http://www.keycloak.org/docs/3.4/server_admin/index.html#groups) named "admin"
-
-4. [Add a new user](http://www.keycloak.org/docs/3.4/server_admin/index.html#_create-new-user) with a username of "testuser", email of "test@test.com" and first and last name of "test"
-
-#### Using the Sample Realm File
-
-1. Go to the [Add Realm](http://www.keycloak.org/docs/3.4/server_admin/index.html#_create-realm) page and click the "Select File" button next to the **Import** label.
-
-2. Choose the [sample realm](./alfresco-realm.json) file and click the "Create" button.
+## Configuring Alfresco products
+After deploying the Identity Service and configuring your existing identity provider with it, you will need to configure the properties for Alfresco Content Services and/or Alfresco Process Services to use the Identity Service for authentication.
 
 ## Contributing to Identity Service
-
 We encourage and welcome contributions to this project. For further details please check the [contributing](./CONTRIBUTING.md) file.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project contains the open-source core of this service.
 ## Deploying the Identity Service
 The steps in [Deploying the Identity Service](docs/deploy/is-deploy.md) detail how to deploy the Identity Service into an existing cluster. These steps use a set of default deployment options that can be customized by reading [Customizing an Identity Service deployment](docs/deploy/is-customize.md). It is recommended that you read through the customization options before starting your deployment.
 
-## Configuring identity providers 
+## Configuring Identity Providers 
 Once you have deployed the Identity Service, you can configure your user synchronization with an LDAP instance or setup an existing identity provider to authenticate with the Identity Service.
 
 An example setup has been provided for configuring the Identity Service with a SAML 2.0 identity provider: [PingFederate](docs/config/ping-federate-example.md).

--- a/docs/deploy/is-customize.md
+++ b/docs/deploy/is-customize.md
@@ -14,7 +14,7 @@ It is possible to override some parameters set for the default realm and clients
 
 ### Client redirect URIs
 
-The default redirect URI set during deployment is: `http://localhost*`. Using the `alfresco-identity-service.client.alfresco.redirectUris` property, you can specify a different redirect URI similar to the following example:
+The default redirect URI set during deployment is: `http://localhost*`. When deploying the Identity Service to a remote system, this URI should be changed to match the hostname of the remote system. Use the `alfresco-identity-service.client.alfresco.redirectUris` property to specify a different redirect URI as per the following example:
 
 ```bash
 helm install alfresco-stable/alfresco-infrastructure \

--- a/docs/deploy/is-customize.md
+++ b/docs/deploy/is-customize.md
@@ -59,7 +59,7 @@ helm install alfresco-stable/alfresco-infrastructure \
 You can customize a realm during the deployment process or manually in the administration console after you have deployed the Identity Service.
 
 #### Realm customization during deployment
-The below steps advise how to add a realm file to your deployment that contains details of its configuration.
+The following steps advise how to add a realm file to your deployment that contains details of its configuration.
 
 1. Create a realm file. A [sample realm](../../helm/alfresco-identity-service/alfresco-realm.json) file is contained in this project.
 
@@ -89,7 +89,7 @@ The below steps advise how to add a realm file to your deployment that contains 
 4. Once the deployment has finished, sign in to the [Management Console](http://www.keycloak.org/docs/4.5/server_admin/index.html#admin-console) to configure your new realm.
 
 #### Manually customize a realm post-deployment
-The below steps describe how to add a new realm manually post-deployment.
+The following steps describe how to add a new realm manually post-deployment.
 
 1. Open the administration console and [add a new realm](http://www.keycloak.org/docs/4.5/server_admin/index.html#_create-realm) called *Alfresco*.
 
@@ -100,7 +100,7 @@ The below steps describe how to add a new realm manually post-deployment.
 4. [Add a new user](http://www.keycloak.org/docs/4.5/server_admin/index.html#_create-new-user) with a username of "testuser", email of "test@test.com" and first and last name of "test".
 
 #### Manually import a realm file post-deployment
-The below steps explain how to import a realm file post-deployment.
+The following steps explain how to import a realm file post-deployment.
 
 1. Create a realm file based on the [sample realm file](../../helm/alfresco-identity-service/alfresco-realm.json) provided in this project, or just use the sample file as it is.
 

--- a/docs/deploy/is-customize.md
+++ b/docs/deploy/is-customize.md
@@ -1,0 +1,107 @@
+# Customizing an Identity Service deployment
+
+## Increasing resilience
+There are a number of options for increasing the availability and resilience of a deployment.
+
+### Replicas
+During deployment you can specify multiple replicas to increase the resilience of an Identity Service deployment.
+
+To enable multiple replicas, use the following command during the Helm chart deployment:
+
+```bash
+--set alfresco-infrastructure.alfresco-identity-service.keycloak.keycloak.replicas=3
+```
+
+### Clustering
+
+Clustering is another method that can be used to increase the resilience of a deployment. Information on how to configure clustering is available in the following locations:
+
+
+* [High availability and clustering](https://github.com/helm/charts/tree/master/stable/keycloak#high-availability-and-clustering)
+
+
+* [Standalone clustered mode](https://www.keycloak.org/docs/4.5/server_installation/#standalone-clustered-configuration)
+
+
+* [Clustering](https://www.keycloak.org/docs/4.5/server_installation/#_clustering)
+
+
+**Note:** Keycloak recommends that [sticky sessions](https://www.keycloak.org/docs/4.5/server_installation/#sticky-sessions) are used, so be aware if you are using an ingress other than Nginx.
+
+## Client and realm customization
+It is possible to override some parameters set for the default realm and clients during and post-deployment.
+
+### Client redirect URIs
+
+The default redirect URI set during deployment is: `http://localhost*`. Using the `alfresco-identity-service.client.alfresco.redirectUris` property, you can specify a different redirect URI similar to the following example:
+
+```bash
+helm install alfresco-stable/alfresco-infrastructure \
+  --set alfresco-infrastructure.activemq.enabled=false \
+  --set alfresco-infrastructure.nginx-ingress.enabled=true \
+  --set alfresco-infrastructure.alfresco-identity-service.enabled=true \
+  --set alfresco-identity-service.client.alfresco.redirectUris=['\"'http://$DNSNAME*'"\'] \
+  --namespace $DESIREDNAMESPACE
+```
+
+It is also possible to specify multiple redirect URIs using the same property:
+
+```bash
+helm install alfresco-stable/alfresco-infrastructure \
+  --set alfresco-infrastructure.activemq.enabled=false \
+  --set alfresco-infrastructure.nginx-ingress.enabled=true \
+  --set alfresco-infrastructure.alfresco-identity-service.enabled=true \
+  --set alfresco-identity-service.redirectUris=['\"'http://$DNSNAME*'"\'',''\"'http://$DNSNAME1*'"\'',''\"'http://$DNSNAME2*'"\']` \
+  --namespace $DESIREDNAMESPACE
+```
+
+### Customizing the realm
+You can customize a realm during the deployment process or manually in the administration console after you have deployed the Identity Service.
+
+#### Realm customization during deployment
+The below steps advise how to add a realm file to your deployment that contains details of its configuration.
+
+1. Create a realm file. A [sample realm](../../helm/alfresco-identity-service/alfresco-realm.json) file is contained in this project.
+
+2. Create a secret using your realm json file:
+
+	```bash
+	kubectl create secret generic realm-secret \
+  	--from-file=./realm.json \
+  	--namespace=$DESIREDNAMESPACE
+	```
+
+	**Note:** The name of the secret must be realm-secret and the name of the realm file must **not** be alfresco-realm.json.
+
+3. Deploy the identity chart with the additional parameters:
+
+	```bash
+	helm repo add alfresco-stable https://kubernetes-charts.alfresco.com/stable
+
+	helm install alfresco-stable/alfresco-infrastructure \
+  	--set alfresco-infrastructure.activemq.enabled=false \
+  	--set alfresco-infrastructure.nginx-ingress.enabled=true \
+  	--set alfresco-infrastructure.alfresco-identity-service.enabled=true \
+  	--set alfresco-infrastructure.alfresco-identity-service.keycloak.keycloak.extraArgs="-Dkeycloak.import=/realm/realm.json" \
+  	--namespace $DESIREDNAMESPACE
+	```
+
+4. Once the deployment has finished, sign in to the [Management Console](http://www.keycloak.org/docs/4.5/server_admin/index.html#admin-console) to configure your new realm.
+
+#### Manually customize a realm post-deployment
+The below steps describe how to add a new realm manually post-deployment.
+
+1. Open the administration console and [add a new realm](http://www.keycloak.org/docs/4.5/server_admin/index.html#_create-realm) called *Alfresco*.
+
+2. [Create an OIDC client](http://www.keycloak.org/docs/4.5/server_admin/index.html#oidc-clients) called *alfresco* within the Alfresco realm you created in Step 1.
+
+3. [Create a group](http://www.keycloak.org/docs/4.5/server_admin/index.html#groups) called *admin*.
+
+4. [Add a new user](http://www.keycloak.org/docs/4.5/server_admin/index.html#_create-new-user) with a username of "testuser", email of "test@test.com" and first and last name of "test".
+
+#### Manually import a realm file post-deployment
+The below steps explain how to import a realm file post-deployment.
+
+1. Create a realm file based on the [sample realm file](../../helm/alfresco-identity-service/alfresco-realm.json) provided in this project, or just use the sample file as it is.
+
+2. Open the administration console and [add a new realm](http://www.keycloak.org/docs/4.5/server_admin/index.html#_create-realm). On the details page choose the **Select File** option and import your realm file, then click **Create**.

--- a/docs/deploy/is-customize.md
+++ b/docs/deploy/is-customize.md
@@ -1,9 +1,6 @@
 # Customizing an Identity Service deployment
 
-## Increasing resilience
-There are a number of options for increasing the availability and resilience of a deployment.
-
-### Replicas
+## Replicas
 During deployment you can specify multiple replicas to increase the resilience of an Identity Service deployment.
 
 To enable multiple replicas, use the following command during the Helm chart deployment:
@@ -11,22 +8,6 @@ To enable multiple replicas, use the following command during the Helm chart dep
 ```bash
 --set alfresco-infrastructure.alfresco-identity-service.keycloak.keycloak.replicas=3
 ```
-
-### Clustering
-
-Clustering is another method that can be used to increase the resilience of a deployment. Information on how to configure clustering is available in the following locations:
-
-
-* [High availability and clustering](https://github.com/helm/charts/tree/master/stable/keycloak#high-availability-and-clustering)
-
-
-* [Standalone clustered mode](https://www.keycloak.org/docs/4.5/server_installation/#standalone-clustered-configuration)
-
-
-* [Clustering](https://www.keycloak.org/docs/4.5/server_installation/#_clustering)
-
-
-**Note:** Keycloak recommends that [sticky sessions](https://www.keycloak.org/docs/4.5/server_installation/#sticky-sessions) are used, so be aware if you are using an ingress other than Nginx.
 
 ## Client and realm customization
 It is possible to override some parameters set for the default realm and clients during and post-deployment.

--- a/docs/deploy/is-deploy.md
+++ b/docs/deploy/is-deploy.md
@@ -52,7 +52,7 @@ The following steps detail a default deployment of the Identity Service. See [Cu
 4. Set your local or ELB IP address as a variable for future use:
 
 	```
-	export ELBADDRESS=$(kubectl get services $RELEASENAME-nginx-ingress-controller --	namespace=$DESIREDNAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+	export ELBADDRESS=$(kubectl get services $RELEASENAME-nginx-ingress-controller --namespace=$DESIREDNAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 	```
 
 5. The default realm values are as follows. You should update all administrator passwords to more complex ones after you have deployed the Identity Service.

--- a/docs/deploy/is-deploy.md
+++ b/docs/deploy/is-deploy.md
@@ -19,7 +19,7 @@ The following steps detail a default deployment of the Identity Service. See [Cu
 
 * [default client redirect URIs](./is-customize.md#client-redirect-uris)
 * [realm customization](./is-customize.md#customizing-the-realm)
-* [increasing resilience and clustering](./is-customize.md#clustering)
+* [increasing resiliency using replicas](./is-customize.md#replicas)
 
 1. You need to deploy the [Alfresco Infrastructure chart](https://github.com/Alfresco/alfresco-infrastructure-deployment#1-deploy-the-infrastructure-charts) in order to deploy the Identity Service. Use the following command to deploy it:
 

--- a/docs/deploy/is-deploy.md
+++ b/docs/deploy/is-deploy.md
@@ -63,6 +63,3 @@ The following steps detail a default deployment of the Identity Service. See [Cu
 	| Admin User Password           | `admin`                  |
 	| Admin User Email              | `admin@app.activiti.com` |
 	| Alfresco Client Redirect URIs | `http://localhost*`      |
-
-**Note:** Alfresco Process Services requires an email address as the username.
-

--- a/docs/deploy/is-deploy.md
+++ b/docs/deploy/is-deploy.md
@@ -47,7 +47,7 @@ The following steps detail a default deployment of the Identity Service. See [Cu
 	helm status $RELEASENAME
 	```
 	
-	You need to wait until the status is ``READY 1/1``.
+	In the Pods section of the response, you need to wait until the status is ``1/1`` in the ``READY`` column for all pods.
 
 4. Set your local or ELB IP address as a variable for future use:
 

--- a/docs/deploy/is-deploy.md
+++ b/docs/deploy/is-deploy.md
@@ -1,0 +1,68 @@
+# Alfresco Identity Service deployment
+
+## Prerequisites
+An Identity Service deployment requires the following:
+
+* A Kubernetes cluster (Kops or EKS)
+* The following components:
+
+|Component  |Getting Started guide                                    |
+|-----------|---------------------------------------------------------|
+|Docker     |https://docs.docker.com/                                 |
+|Helm       |https://docs.helm.sh/using_helm/#quickstart-guide        |
+|Kubectl    |https://kubernetes.io/docs/tasks/tools/install-kubectl/  |
+
+The Identity Service can also be deployed on Docker for Desktop for development and trial purposes.
+
+## Deploying the Identity Service
+The following steps detail a default deployment of the Identity Service. See [Customizing an Identity Service deployment](./is-customize.md) for additional parameters to change or update values for:
+
+* [default client redirect URIs](./is-customize.md#client-redirect-uris)
+* [realm customization](./is-customize.md#customizing-the-realm)
+* [increasing resilience and clustering](./is-customize.md#clustering)
+
+1. You need to deploy the [Alfresco Infrastructure chart](https://github.com/Alfresco/alfresco-infrastructure-deployment#1-deploy-the-infrastructure-charts) in order to deploy the Identity Service. Use the following command to deploy it:
+
+   **Note:** Nginx Ingress is required for the Identity Service. Active-MQ is not required so the relevant property can be set to ``false`` as it is in the following command.
+   
+   ```
+   helm repo add alfresco-stable https://kubernetes-charts.alfresco.com/stable
+
+   helm install alfresco-stable/alfresco-infrastructure \
+     --set alfresco-infrastructure.activemq.enabled=false \
+     --set alfresco-infrastructure.nginx-ingress.enabled=true \
+     --set alfresco-infrastructure.alfresco-identity-service.enabled=true \
+     --namespace $DESIREDNAMESPACE
+   ```
+
+2. The previous command will assign a release name to your deployment (e.g. ``knobby-wolf``). Set this release name as a variable:
+
+   ```
+   export RELEASENAME=knobby-wolf
+   ```
+
+3. Check the status of your release using the following command:
+
+	```
+	helm status $RELEASENAME
+	```
+	
+	You need to wait until the status is ``READY 1/1``.
+
+4. Set your local or ELB IP address as a variable for future use:
+
+	```
+	export ELBADDRESS=$(kubectl get services $RELEASENAME-nginx-ingress-controller --	namespace=$DESIREDNAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+	```
+
+5. The default realm values are as follows. You should update all administrator passwords to more complex ones after you have deployed the Identity Service.
+
+	| Property                      | Value                    |
+	| ----------------------------- | ------------------------ |
+	| Admin User Username           | `admin`                  |
+	| Admin User Password           | `admin`                  |
+	| Admin User Email              | `admin@app.activiti.com` |
+	| Alfresco Client Redirect URIs | `http://localhost*`      |
+
+**Note:** Alfresco Process Services requires an email address as the username.
+


### PR DESCRIPTION
Separated deployment and configuration from the main README. 
Will update the README with instructions for ACS / APS once they are done. 