### PR TITLE
[AUTH-213] Deprecated clientTemplates configuration in alfresco realm

### DIFF
--- a/helm/alfresco-identity-service/alfresco-realm.json
+++ b/helm/alfresco-identity-service/alfresco-realm.json
@@ -1082,7 +1082,6 @@
       "useTemplateMappers": false
     }
   ],
-  "clientTemplates": [],
   "browserSecurityHeaders": {
     "xContentTypeOptions": "nosniff",
     "xRobotsTag": "none",


### PR DESCRIPTION
-Remove clientTemplates configuration from alfresco-realm.json
