### PR TITLE
set postgres password to avoid reseting on upgrade

### DIFF
--- a/helm/alfresco-identity-service/values.yaml
+++ b/helm/alfresco-identity-service/values.yaml
@@ -101,6 +101,7 @@ keycloak:
   postgresql:
     nameOverride: postgresql-id
     imageTag: "10.1"
+    postgresPassword: "keycloak"
     persistence:
       enabled: true
       existingClaim: "alfresco-volume-claim"


### PR DESCRIPTION
I think this would resolve https://issues.alfresco.com/jira/browse/AUTH-189 reported by @mteodori that password authentication fails every time you upgrade helm release

Seems to work from [testing with activiti](https://github.com/Activiti/activiti-cloud-charts/pull/51/commits/64d41e183b2dd40abe5eb48ab374988b65657fdf#diff-8e9b5b5cf988767272f16d363998e613R146)