### PR TITLE
support client roles

### DIFF
--- a/helm/alfresco-identity-service/alfresco-realm.json
+++ b/helm/alfresco-identity-service/alfresco-realm.json
@@ -329,6 +329,12 @@
           "containerId": "140feb9e-fd73-4d02-97f6-928ed67020f1"
         }
       ]
+      {{- if .Values.realm.alfresco.extraClientRoles -}}
+        {{- range .Values.realm.alfresco.extraClientRoles -}}
+        ,
+        {{ . | toJson }}
+        {{- end }}
+        {{- end }}
     }
   },
   "groups": [


### PR DESCRIPTION
APS uses client roles so would be needed if APS were to build on common base realm