### PR TITLE
ingress host name appears to be unused

### DIFF
--- a/helm/alfresco-identity-service/values.yaml
+++ b/helm/alfresco-identity-service/values.yaml
@@ -7,7 +7,6 @@ ingress:
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "identity_affinity_route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
-ingressHostName: "your ingress dns name"
 
 realm:
   alfresco:


### PR DESCRIPTION
Should either [support it in the ingress yaml](https://github.com/Alfresco/alfresco-identity-service/blob/master/helm/alfresco-identity-service/templates/identity-ingress.yaml#L12) or remove it from the values file.