### PR TITLE
AUTH-259: Provide a helm chart that includes IDS 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Using the following command only the Identity Service and the [nginx-ingress](ht
 ```bash
 
 helm repo add alfresco-stable https://kubernetes-charts.alfresco.com/stable
+helm repo add codecentric https://codecentric.github.io/helm-charts
 
 helm install alfresco-stable/alfresco-infrastructure \
   --set alfresco-infrastructure.activemq.enabled=false \
@@ -259,6 +260,7 @@ kubectl create secret generic realm-secret \
 ```bash
 
 helm repo add alfresco-stable https://kubernetes-charts.alfresco.com/stable
+helm repo add codecentric https://codecentric.github.io/helm-charts
 
 helm install alfresco-stable/alfresco-infrastructure \
   --set alfresco-infrastructure.activemq.enabled=false \

--- a/helm/alfresco-identity-service/Chart.yaml
+++ b/helm/alfresco-identity-service/Chart.yaml
@@ -1,5 +1,5 @@
 name: alfresco-identity-service
-version: 1.1.2
+version: 1.1.2-AUTH-259
 description: The Alfresco Identity Service will become the central component responsible for identity-related capabilities needed by other Alfresco software, such as managing users, groups, roles, profiles, and authentication. Currently it deals just with authentication.
 keywords:
   - alfresco

--- a/helm/alfresco-identity-service/Chart.yaml
+++ b/helm/alfresco-identity-service/Chart.yaml
@@ -1,5 +1,5 @@
 name: alfresco-identity-service
-version: 1.1.2-AUTH-259
+version: 1.1.3
 appVersion: 1.2.0
 description: The Alfresco Identity Service will become the central component responsible for identity-related capabilities needed by other Alfresco software, such as managing users, groups, roles, profiles, and authentication. Currently it deals just with authentication.
 keywords:

--- a/helm/alfresco-identity-service/Chart.yaml
+++ b/helm/alfresco-identity-service/Chart.yaml
@@ -1,5 +1,6 @@
 name: alfresco-identity-service
 version: 1.1.2-AUTH-259
+appVersion: 1.2.0
 description: The Alfresco Identity Service will become the central component responsible for identity-related capabilities needed by other Alfresco software, such as managing users, groups, roles, profiles, and authentication. Currently it deals just with authentication.
 keywords:
   - alfresco

--- a/helm/alfresco-identity-service/requirements.yaml
+++ b/helm/alfresco-identity-service/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: keycloak
-    version: 4.3.0
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    version: 5.1.7
+    repository: https://codecentric.github.io/helm-charts

--- a/helm/alfresco-identity-service/values.yaml
+++ b/helm/alfresco-identity-service/values.yaml
@@ -59,6 +59,9 @@ realm:
           - "/testgroup"
 
 keycloak:
+  image:
+    repository: quay.io/alfresco/alfresco-identity-service
+    tag: 1.2
   rbac:
     create: false
   keycloak:
@@ -79,19 +82,19 @@ keycloak:
             cp -R /alfresco/* /theme
         volumeMounts:
           - name: theme
-            mountPath: /theme    
+            mountPath: /theme
     extraVolumes: |
       - name: realm-secret
         secret:
           secretName: realm-secret
       - name: theme
-        emptyDir: {}    
+        emptyDir: {}
     extraVolumeMounts: |
       - name: realm-secret
         mountPath: "/realm/"
         readOnly: true
       - name: theme
-        mountPath: /opt/jboss/keycloak/themes/alfresco  
+        mountPath: /opt/jboss/keycloak/themes/alfresco
     extraArgs: "-Dkeycloak.import=/realm/alfresco-realm.json"
     persistence:
       deployPostgres: true


### PR DESCRIPTION
- Upgraded the Keycloak helm chart requirement
- Added app Version
- Changed image 