### PR TITLE
[DEPLOY-869] Document setting bind address when starting AIMS standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ This guide helps you get started with the Identity Service. It covers simple sta
   Linux/Unix
   ```bash
   $ cd alfresco-identity-service-1.2.0/bin
-  $ ./standalone.sh
+  $ ./standalone.sh -b <IP_ADDRESS>
   ```
+  **_NOTE:_** To bind to all public interfaces use `0.0.0.0` as the value of IP_ADDRESS.
 
   Windows bat
   ```bash

--- a/README.md
+++ b/README.md
@@ -36,16 +36,15 @@ This guide helps you get started with the Identity Service. It covers simple sta
   $ cd alfresco-identity-service-1.2.0/bin
   $ ./standalone.sh -b <IP_ADDRESS>
   ```
-  **_NOTE:_** To bind to all public interfaces use `0.0.0.0` as the value of IP_ADDRESS.
-
   Windows bat
   ```bash
-  > ...\alfresco-identity-service-1.2.0\bin\standalone.bat
+  > ...\alfresco-identity-service-1.2.0\bin\standalone.bat -b <IP_ADDRESS>
   ```
   Windows powershell
   ```bash
-  > ...\alfresco-identity-service-1.2.0\bin\standalone.ps1
+  > ...\alfresco-identity-service-1.2.0\bin\standalone.ps1 -b <IP_ADDRESS>
   ```
+  **_NOTE:_** To bind to all public interfaces use `0.0.0.0` as the value of IP_ADDRESS otherwise specify the the address of the specific interface you want to use.
 
 This is deployed with the **default example realm applied** which results in default values of:
 


### PR DESCRIPTION
- Update command example
- Add note about binding to all public interfaces.
- Expand to other OS examples
- Clarify IP address use beyond binding to all public interfaces