### PR TITLE
AUTH-481: K8s cleanup job error in Identity Service 1.2

### DIFF
--- a/helm/alfresco-identity-service/templates/roleBinding.yaml
+++ b/helm/alfresco-identity-service/templates/roleBinding.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-delete-pvc-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    resourceNames: ["backup-{{ template "alfresco-identity.fullname" . }}"]
+    verbs: ["delete"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-keycloak-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-delete-pvc-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-keycloak
+    namespace: {{ .Release.Namespace }}

--- a/helm/alfresco-identity-service/templates/roleBinding.yaml
+++ b/helm/alfresco-identity-service/templates/roleBinding.yaml
@@ -22,5 +22,5 @@ roleRef:
   name: {{ .Release.Name }}-delete-pvc-role
 subjects:
   - kind: ServiceAccount
-    name: {{ template "keycloak.fullname" . }}
+    name: {{ include "keycloak.fullname" . }}
     namespace: {{ .Release.Namespace }}

--- a/helm/alfresco-identity-service/templates/roleBinding.yaml
+++ b/helm/alfresco-identity-service/templates/roleBinding.yaml
@@ -22,5 +22,5 @@ roleRef:
   name: {{ .Release.Name }}-delete-pvc-role
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-keycloak
+    name: {{ template "keycloak.fullname" . }}
     namespace: {{ .Release.Namespace }}

--- a/helm/alfresco-identity-service/templates/upgrade-job.yaml
+++ b/helm/alfresco-identity-service/templates/upgrade-job.yaml
@@ -309,7 +309,7 @@ spec:
         chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     spec:
       restartPolicy: "OnFailure"
-      serviceAccountName: {{ .Release.Name }}-keycloak
+      serviceAccountName: {{ include "keycloak.fullname" . }}
       containers:
         - name: vol-clean
           image: "{{ .Values.hyperkube.image.repository }}:{{ .Values.hyperkube.image.tag }}"

--- a/helm/alfresco-identity-service/templates/upgrade-job.yaml
+++ b/helm/alfresco-identity-service/templates/upgrade-job.yaml
@@ -31,7 +31,7 @@ spec:
             - bash
             - -c
             - |
-              kubectl delete --ignore-not-found sts {{ template "keycloak.fullname" . }} && kubectl delete --ignore-not-found secret realm-secret 
+              kubectl delete --ignore-not-found sts {{ template "keycloak.fullname" . }} && kubectl delete --ignore-not-found secret realm-secret
               sleep 5
 ---
 {{- if .Values.keycloak.persistence.deployPostgres }}
@@ -47,7 +47,7 @@ metadata:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": pre-upgrade #Determines time of deploy
-    "helm.sh/hook-weight": "0" #Determines the order if multiple hooks are deffined    
+    "helm.sh/hook-weight": "0" #Determines the order if multiple hooks are deffined
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   accessModes:
@@ -295,7 +295,7 @@ metadata:
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
-    "helm.sh/hook": post-delete #Determines time of deploy
+    "helm.sh/hook": pre-delete #Determines time of deploy
     "helm.sh/hook-weight": "1" #Determines the order if multiple hooks are deffined
     "helm.sh/hook-delete-policy": hook-succeeded #Determines when is the object deleted
 spec:
@@ -309,6 +309,7 @@ spec:
         chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     spec:
       restartPolicy: "OnFailure"
+      serviceAccountName: {{ .Release.Name }}-keycloak
       containers:
         - name: vol-clean
           image: "{{ .Values.hyperkube.image.repository }}:{{ .Values.hyperkube.image.tag }}"

--- a/helm/alfresco-identity-service/values.yaml
+++ b/helm/alfresco-identity-service/values.yaml
@@ -68,6 +68,8 @@ keycloak:
       pullPolicy: Always
       pullSecrets:
         - quay-registry-secret
+    serviceAccount:
+      create: true
     username: admin
     password: admin
     service:
@@ -85,7 +87,7 @@ keycloak:
       deployPostgres: true
       dbVendor: postgres
       dbPassword: keycloak
-  ### Since conditions in the requirements file are global values 
+  ### Since conditions in the requirements file are global values
   ### the next entry actually decides if the postgress chart is being installed or not.
   persistence:
     deployPostgres: true


### PR DESCRIPTION
Enabled the Keycloak's service account to be created at deploy time, created a role that gives permissions to delete the back PVC and bound that role to Keycloak's service account. 