### PR TITLE
ACS-275: Parametrize upgrade and rollback db version and key

### DIFF
--- a/helm/alfresco-identity-service/Chart.yaml
+++ b/helm/alfresco-identity-service/Chart.yaml
@@ -1,5 +1,5 @@
 name: alfresco-identity-service
-version: 2.0.1
+version: 2.0.2
 appVersion: 1.3.0-A1
 description: The Alfresco Identity Service will become the central component responsible for identity-related capabilities needed by other Alfresco software, such as managing users, groups, roles, profiles, and authentication. Currently it deals just with authentication.
 keywords:

--- a/helm/alfresco-identity-service/templates/rollback-job.yaml
+++ b/helm/alfresco-identity-service/templates/rollback-job.yaml
@@ -103,14 +103,14 @@ spec:
       restartPolicy: "OnFailure"
       containers:
         - name: rb-restore
-          image: "postgres:10.1"
+          image: {{ .Values.keycloak.postgresql.rollback.image }}
           imagePullPolicy: "IfNotPresent"
           env:
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Release.Name }}-{{ .Values.keycloak.postgresql.nameOverride }}
-                  key: postgres-password
+                  key: {{ .Values.keycloak.postgresql.rollback.password_key }}
           command:
             - bash
             - -c

--- a/helm/alfresco-identity-service/templates/rollback-job.yaml
+++ b/helm/alfresco-identity-service/templates/rollback-job.yaml
@@ -103,14 +103,14 @@ spec:
       restartPolicy: "OnFailure"
       containers:
         - name: rb-restore
-          image: {{ .Values.keycloak.postgresql.rollback.image }}
+          image: {{ .Values.keycloak.postgresql.restore.image }}
           imagePullPolicy: "IfNotPresent"
           env:
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Release.Name }}-{{ .Values.keycloak.postgresql.nameOverride }}
-                  key: {{ .Values.keycloak.postgresql.rollback.password_key }}
+                  key: {{ .Values.keycloak.postgresql.restore.password_key }}
           command:
             - bash
             - -c

--- a/helm/alfresco-identity-service/templates/upgrade-job.yaml
+++ b/helm/alfresco-identity-service/templates/upgrade-job.yaml
@@ -85,14 +85,14 @@ spec:
       restartPolicy: "OnFailure"
       containers:
         - name: up-backup
-          image: {{ .Values.keycloak.postgresql.upgrade.image }}
+          image: {{ .Values.keycloak.postgresql.backup.image }}
           imagePullPolicy: "IfNotPresent"
           env:
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Release.Name }}-{{ .Values.keycloak.postgresql.nameOverride }}
-                  key: {{ .Values.keycloak.postgresql.upgrade.password_key }}
+                  key: {{ .Values.keycloak.postgresql.backup.password_key }}
           command:
             - bash
             - -c
@@ -214,14 +214,14 @@ spec:
       restartPolicy: "OnFailure"
       containers:
         - name: up-restore
-          image: {{ .Values.keycloak.postgresql.upgrade.image }}
+          image: {{ .Values.keycloak.postgresql.restore.image }}
           imagePullPolicy: "IfNotPresent"
           env:
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Release.Name }}-{{ .Values.keycloak.postgresql.nameOverride }}
-                  key: {{ .Values.keycloak.postgresql.upgrade.password_key }}
+                  key: {{ .Values.keycloak.postgresql.restore.password_key }}
           command:
             - bash
             - -c

--- a/helm/alfresco-identity-service/templates/upgrade-job.yaml
+++ b/helm/alfresco-identity-service/templates/upgrade-job.yaml
@@ -85,14 +85,14 @@ spec:
       restartPolicy: "OnFailure"
       containers:
         - name: up-backup
-          image: "postgres:10.1"
+          image: {{ .Values.keycloak.postgresql.upgrade.image }}
           imagePullPolicy: "IfNotPresent"
           env:
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Release.Name }}-{{ .Values.keycloak.postgresql.nameOverride }}
-                  key: postgres-password
+                  key: {{ .Values.keycloak.postgresql.upgrade.password_key }}
           command:
             - bash
             - -c
@@ -214,14 +214,14 @@ spec:
       restartPolicy: "OnFailure"
       containers:
         - name: up-restore
-          image: "postgres:11.1"
+          image: {{ .Values.keycloak.postgresql.upgrade.image }}
           imagePullPolicy: "IfNotPresent"
           env:
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Release.Name }}-{{ .Values.keycloak.postgresql.nameOverride }}
-                  key: postgresql-password
+                  key: {{ .Values.keycloak.postgresql.upgrade.password_key }}
           command:
             - bash
             - -c

--- a/helm/alfresco-identity-service/values.yaml
+++ b/helm/alfresco-identity-service/values.yaml
@@ -104,6 +104,17 @@ keycloak:
         memory: "250Mi"
       limits:
         memory: "500Mi"
+    ### Following rollback and upgrade values are used for backing up and restoring postgres db along with the helm chart
+    ### This is currently setup to adapt to 1.1 to 1.2 upgrades only when the db is in k8s
+    rollback:
+      image: "postgres:10.1"
+      password_key: "postgres-password"
+    restore:
+      image: "postgres:11.1"
+      password_key: "postgresql-password"
+    backup:
+      image: "postgres:10.1"
+      password_key: "postgres-password"
 
 ## Used to run 'kubectl' in kubernetes jobs for backup and restoration purposes
 hyperkube:

--- a/helm/alfresco-identity-service/values.yaml
+++ b/helm/alfresco-identity-service/values.yaml
@@ -105,7 +105,6 @@ keycloak:
       limits:
         memory: "500Mi"
     ### Following values are used for backing up and restoring postgres db along with the helm chart
-    ### This is currently setup to adapt to 1.1 to 1.2 upgrades only when the db is in k8s
     restore:
       image: "postgres:11.1"
       password_key: "postgresql-password"

--- a/helm/alfresco-identity-service/values.yaml
+++ b/helm/alfresco-identity-service/values.yaml
@@ -104,11 +104,8 @@ keycloak:
         memory: "250Mi"
       limits:
         memory: "500Mi"
-    ### Following rollback and upgrade values are used for backing up and restoring postgres db along with the helm chart
+    ### Following values are used for backing up and restoring postgres db along with the helm chart
     ### This is currently setup to adapt to 1.1 to 1.2 upgrades only when the db is in k8s
-    rollback:
-      image: "postgres:11.1"
-      password_key: "postgresql-password"
     restore:
       image: "postgres:11.1"
       password_key: "postgresql-password"

--- a/helm/alfresco-identity-service/values.yaml
+++ b/helm/alfresco-identity-service/values.yaml
@@ -107,14 +107,14 @@ keycloak:
     ### Following rollback and upgrade values are used for backing up and restoring postgres db along with the helm chart
     ### This is currently setup to adapt to 1.1 to 1.2 upgrades only when the db is in k8s
     rollback:
-      image: "postgres:10.1"
-      password_key: "postgres-password"
+      image: "postgres:11.1"
+      password_key: "postgresql-password"
     restore:
       image: "postgres:11.1"
       password_key: "postgresql-password"
     backup:
-      image: "postgres:10.1"
-      password_key: "postgres-password"
+      image: "postgres:11.1"
+      password_key: "postgresql-password"
 
 ## Used to run 'kubectl' in kubernetes jobs for backup and restoration purposes
 hyperkube:


### PR DESCRIPTION
Issue appears on:
Identity service chart version: 2.0.1
appVersion: 1.3.0-A1

Identity service fails to upgrade properly with just a simple values change

The backup and restore jobs are failing since the backup job is looking for a posgresql-id secret that only exists in identity 1.1 version.

Making the image and secret key configurable should take care of this issue.

However in addition to that we need to settle on the appropriate default values. Since we got to 1.3 already with this chart and upgrade was purposed for 1.1 > 1.2.

And for going to 1.2 > 1.3 the value for the secret key needs to be postgresql-password as default for both backup and restore. 