### PR TITLE
fix for AAE-3212 Error: jobs.batch  already exists

### DIFF
--- a/helm/alfresco-identity-service/templates/upgrade-job.yaml
+++ b/helm/alfresco-identity-service/templates/upgrade-job.yaml
@@ -287,7 +287,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: vol-clean-{{ template "alfresco-identity.fullname" . }}
+  name: vol-clean-{{ template "alfresco-identity.fullname" . }}-{{ randAlphaNum 5 | lower }}
   labels:
     heritage: {{.Release.Service | quote }}
     release: {{.Release.Name | quote }}


### PR DESCRIPTION
vol-clean-{{ template "alfresco-identity.fullname" . }} updated to   name: vol-clean-{{ template "alfresco-identity.fullname" . }}-{{ randAlphaNum 5 | lower }}
based on https://github.com/helm/helm/issues/1769 our issue is https://issues.alfresco.com/jira/browse/AAE-3212