### PR TITLE
OPSEXP-1095 csi driver update

### DIFF
--- a/test/helm/test-values.yaml
+++ b/test/helm/test-values.yaml
@@ -16,7 +16,7 @@ keycloak:
       value: admin
     - name: KEYCLOAK_IMPORT
       value: /realm/alfresco-realm.json
-  postgres:
+  postgresql:
     persistence:
       existingClaim: ""
       storageClaas: "gp2"

--- a/test/helm/test-values.yaml
+++ b/test/helm/test-values.yaml
@@ -19,7 +19,7 @@ keycloak:
   postgresql:
     persistence:
       existingClaim: ""
-      storageClaas: "gp2"
+      storageClass: "gp2"
 
   livenessProbe: |
     httpGet:

--- a/test/helm/test-values.yaml
+++ b/test/helm/test-values.yaml
@@ -16,6 +16,10 @@ keycloak:
       value: admin
     - name: KEYCLOAK_IMPORT
       value: /realm/alfresco-realm.json
+  postgres:
+    persistence:
+      existingClaim: ""
+      storageClaas: "gp2"
 
   livenessProbe: |
     httpGet:


### PR DESCRIPTION
This PR allow for deploying on EKS 1.21 with the newer aws-efs-csi-driver (deployed as part of the cluster installation instead of the nfs-client-provisionner).
The goal is to:
* Stop using the alfresco-volume-claim for postgresql related services
* using dynamic PVC
* rely on the gp2 storageClass for automatic provisioning that's compatible with the service. 

Ref. OPSEXP-1095