### PR TITLE
OPSEXP-1338 Support k8s 1.22 in IDS chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ alfresco-identity-service-*
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
-requirements.lock
+Chart.lock
 
 #IntelliJ project files
 .idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 repos:
+  - repo: https://github.com/norwoodj/helm-docs
+    rev: v1.7.0
+    hooks:
+      - id: helm-docs
   - repo: https://github.com/Alfresco/alfresco-build-tools
     rev: v1.2.0
     hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ import:
   - source: Alfresco/alfresco-build-tools:.travis.aws-iam-authenticator_install.yml@v1.2.1
   - source: Alfresco/alfresco-build-tools:.travis.kubernetes_install.yml@v1.2.1
   - source: Alfresco/alfresco-build-tools:.travis.helm_install.yml@v1.2.1
+  - source: Alfresco/alfresco-build-tools:.travis.helm-docs_install.yml@v1.2.1
   - source: Alfresco/alfresco-build-tools:.travis.pre-commit.yml@v1.2.1
 
 language: java
@@ -28,6 +29,7 @@ stages:
 
 env:
   global:
+    - HELM_DOCS_VERSION=1.7.0
     - TRAVIS_WAIT_TIMEOUT=${TRAVIS_WAIT_TIMEOUT:-30}
     - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH}}
     - HELM_REPO_BASE_URL=https://kubernetes-charts.alfresco.com

--- a/helm/alfresco-identity-service/Chart.yaml
+++ b/helm/alfresco-identity-service/Chart.yaml
@@ -1,14 +1,21 @@
-apiVersion: v1
+apiVersion: v2
 name: alfresco-identity-service
-version: 5.0.0
+version: 5.1.0
 appVersion: 1.6.0
 description: The Alfresco Identity Service will become the central component responsible for identity-related capabilities needed by other Alfresco software, such as managing users, groups, roles, profiles, and authentication. Currently it deals just with authentication.
 keywords:
   - alfresco
   - keycloak
   - identity-service
-home: https://github.com/Alfresco/alfresco-identity-service/helm
+home: https://github.com/Alfresco/alfresco-identity-service/tree/master/helm/alfresco-identity-service
 sources:
-  - https://github.com/Alfresco/alfresco-identity-service/helm
+  - https://github.com/Alfresco/alfresco-identity-service
 maintainers:
   - name: Alfresco
+dependencies:
+  - name: keycloak
+    version: 15.0.0
+    repository: https://codecentric.github.io/helm-charts
+  - name: common
+    version: 1.11.3
+    repository: https://charts.bitnami.com/bitnami

--- a/helm/alfresco-identity-service/README.md
+++ b/helm/alfresco-identity-service/README.md
@@ -1,10 +1,10 @@
 # alfresco-identity-service
 
-![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 5.1.0](https://img.shields.io/badge/Version-5.1.0-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
 The Alfresco Identity Service will become the central component responsible for identity-related capabilities needed by other Alfresco software, such as managing users, groups, roles, profiles, and authentication. Currently it deals just with authentication.
 
-**Homepage:** <https://github.com/Alfresco/alfresco-identity-service/helm>
+**Homepage:** <https://github.com/Alfresco/alfresco-identity-service/tree/master/helm/alfresco-identity-service>
 
 ## Maintainers
 
@@ -14,12 +14,13 @@ The Alfresco Identity Service will become the central component responsible for 
 
 ## Source Code
 
-* <https://github.com/Alfresco/alfresco-identity-service/helm>
+* <https://github.com/Alfresco/alfresco-identity-service>
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
+| https://charts.bitnami.com/bitnami | common | 1.11.3 |
 | https://codecentric.github.io/helm-charts | keycloak | 15.0.0 |
 
 ## Values
@@ -33,6 +34,7 @@ The Alfresco Identity Service will become the central component responsible for 
 | ingress.annotations."nginx.ingress.kubernetes.io/session-cookie-name" | string | `"identity_affinity_route"` |  |
 | ingress.enabled | bool | `true` |  |
 | ingress.path | string | `"/auth"` |  |
+| ingress.pathType | string | `"Prefix"` |  |
 | keycloak.extraEnv | string | `"- name: KEYCLOAK_USER\n  value: admin\n- name: KEYCLOAK_PASSWORD\n  value: admin\n- name: KEYCLOAK_IMPORT\n  value: /realm/alfresco-realm.json\n"` |  |
 | keycloak.extraVolumeMounts | string | `"- name: realm-secret\n  mountPath: \"/realm/\"\n  readOnly: true\n"` |  |
 | keycloak.extraVolumes | string | `"- name: realm-secret\n  secret:\n    secretName: realm-secret\n"` |  |

--- a/helm/alfresco-identity-service/requirements.yaml
+++ b/helm/alfresco-identity-service/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-  - name: keycloak
-    version: 15.0.0
-    repository: https://codecentric.github.io/helm-charts

--- a/helm/alfresco-identity-service/templates/identity-ingress.yaml
+++ b/helm/alfresco-identity-service/templates/identity-ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: extensions/v1beta1
+{{- $serviceName :=  printf "%s-%s" (include "keycloak.fullname" .) "http" -}}
+{{- $servicePort := .Values.keycloak.service.httpPort -}}
+apiVersion: {{ template "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "alfresco-identity.fullname" . }}
@@ -17,7 +19,8 @@ spec:
   {{- end }}
       paths:
       - path: {{ .Values.ingress.path }}
-        backend: 
-          serviceName: {{ template "keycloak.fullname" . }}-http
-          servicePort: {{ .Values.keycloak.service.httpPort }}
+        {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+        pathType: {{ .Values.ingress.pathType }}
+        {{- end }}
+        backend: {{- include "common.ingress.backend" (dict "serviceName" $serviceName "servicePort" $servicePort "context" $) | nindent 10 }}
 {{- end }}

--- a/helm/alfresco-identity-service/values.yaml
+++ b/helm/alfresco-identity-service/values.yaml
@@ -1,5 +1,6 @@
 ingress:
   enabled: true
+  pathType: Prefix
   path: /auth
   annotations:
     kubernetes.io/ingress.class: "nginx"
@@ -84,7 +85,6 @@ keycloak:
       value: admin
     - name: KEYCLOAK_IMPORT
       value: /realm/alfresco-realm.json
-  ###
   postgresql:
     enabled: true
     nameOverride: postgresql-id


### PR DESCRIPTION
* add support for new Ingress API using https://artifacthub.io/packages/helm/bitnami/common
* change to helm apiVersion v2 as it's helm 3 only moving requirements to Chart.yaml

Ref. OPSEXP-1338