### PR TITLE
ACS-5924 Make release branch development ready

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - OPSEXP-**
       - feature/**
       - fix/**
+      - release/**
   workflow_dispatch:
   schedule:
     - cron: "0 5 * * 3"
@@ -423,7 +424,7 @@ jobs:
     needs: [test_linux, test_windows, test_helm, test_upgrade]
     if: >
       !(failure() || cancelled()) &&
-      (github.ref_name == 'master' || contains(github.event.head_commit.message, '[publish]')) &&
+      (github.ref_name == 'master' || startsWith(github.ref_name, 'release/') || contains(github.event.head_commit.message, '[publish]')) &&
       github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v3
@@ -444,7 +445,7 @@ jobs:
           global: true
       - name: "Set HELM_REPO"
         run: |
-          if [[ "${BRANCH_NAME}" == "master" ]] && [[ "${{ github.event.head_commit.message }}" == *"[release]"* ]]
+          if [[ "${BRANCH_NAME}" =~ ^master$|^release/.+$ ]] && [[ "${{ github.event.head_commit.message }}" == *"[release]"* ]]
           then
             export HELM_REPO=stable
           fi
@@ -453,7 +454,7 @@ jobs:
       - name: "Publish Helm Chart"
         id: publish
         run: |
-          if [[ "${BRANCH_NAME}" != "master" ]]; then
+          if [[ ! "${BRANCH_NAME}" =~ ^master$|^release/.+$ ]]; then
             CHART_VERSION=$(cat helm/${PROJECT_NAME}/Chart.yaml | grep version: | awk '{print $2}')
             # Only modify the chart version if it doesn't have '-M*' at the end
             if [[ "${CHART_VERSION}" != *"-M"* ]]; then
@@ -529,7 +530,7 @@ jobs:
     needs: staging_release
     if: >
       !(failure() || cancelled()) &&
-      github.ref_name == 'master' &&
+      (github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) &&
       contains(github.event.head_commit.message, '[release]') &&
       github.event_name != 'pull_request'
     steps:
@@ -577,7 +578,7 @@ jobs:
     needs: staging_release
     if: >
       !(failure() || cancelled()) &&
-      github.ref_name == 'master' &&
+      (github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) &&
       contains(github.event.head_commit.message, '[release]') &&
       github.event_name != 'pull_request'
     steps:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The *Alfresco Identity Service* will become the central component responsible for identity-related capabilities needed by other Alfresco software, such as managing users, groups, roles, profiles, and authentication. Currently it deals just with authentication. This project contains the open-source core of this service.
 
-For installing and [upgrading](https://github.com/Alfresco/alfresco-identity-service/blob/master/upgrade.md) the Identity Service you can choose either a Kubernetes distribution or a standalone distribution. Both methods are described in the following sections.
+For installing and [upgrading](https://github.com/Alfresco/alfresco-identity-service/blob/release/2.0.x/upgrade.md) the Identity Service you can choose either a Kubernetes distribution or a standalone distribution. Both methods are described in the following sections.
 
 Check the [Kubernetes deployment prerequisites](https://github.com/Alfresco/alfresco-dbp-deployment/blob/master/README-prerequisite.md) and [standalone prerequisites](#prerequisites) before you start.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ The primary deployment mechanism is via a Kubernetes Helm chart.
 * License: Apache 2
 * Issue Tracker: https://issues.alfresco.com/jira/projects/AUTH
 * Documentation: TODO
-* Contributions: https://github.com/Alfresco/alfresco-identity-service/blob/master/CONTRIBUTING.md
+* Contributions: https://github.com/Alfresco/alfresco-identity-service/blob/release/2.0.x/CONTRIBUTING.md
 
 *** 
 

--- a/helm/alfresco-identity-service/Chart.yaml
+++ b/helm/alfresco-identity-service/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - alfresco
   - keycloak
   - identity-service
-home: https://github.com/Alfresco/alfresco-identity-service/tree/master/helm/alfresco-identity-service
+home: https://github.com/Alfresco/alfresco-identity-service/tree/release/2.0.x/helm/alfresco-identity-service
 sources:
   - https://github.com/Alfresco/alfresco-identity-service
 maintainers:

--- a/helm/alfresco-identity-service/README.md
+++ b/helm/alfresco-identity-service/README.md
@@ -4,7 +4,7 @@
 
 The Alfresco Identity Service will become the central component responsible for identity-related capabilities needed by other Alfresco software, such as managing users, groups, roles, profiles, and authentication. Currently it deals just with authentication.
 
-**Homepage:** <https://github.com/Alfresco/alfresco-identity-service/tree/master/helm/alfresco-identity-service>
+**Homepage:** <https://github.com/Alfresco/alfresco-identity-service/tree/release/2.0.x/helm/alfresco-identity-service>
 
 ## Maintainers
 

--- a/test/saml/pom.xml
+++ b/test/saml/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>io.github.bonigarcia</groupId>
       <artifactId>webdrivermanager</artifactId>
-      <version>4.4.3</version>
+      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Enabling CI/CD and releases from release branches.

Also upgrading the `webdrivermanager` dependency due to https://github.com/bonigarcia/webdrivermanager/commit/0d4967115ec77f6054fb32b4030dddb1db119974 _(Chrome WebDriver endpoint changed as explained here: https://chromedriver.chromium.org/downloads, this causes the tests to fail as they would try to use an older Chrome WebDriver version against a newer Chrome version that is not fully compatible with it)_.