### PR TITLE
ACS-5925 Add "release" instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,10 @@ Once Keycloak is up and running, login to the [Management Console](https://www.k
 
 2. Choose the [sample realm](./alfresco-realm.json) file and click the "Create" button.
 
+## Releasing
+
+The release process is explained [here](docs/RELEASE.md).
+
 ## Contributing
 
 We encourage and welcome contributions to this project. For further details please check the [contributing](./CONTRIBUTING.md) file.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,21 @@
+# Release
+
+There are no artifacts to be distributed, therefore the release process is only required to produce snapshots in time of testing specific Keycloak + Alfresco Keycloak Theme combinations.
+
+Once a new Keycloak + Alfresco Keycloak Theme combination has been thoroughly tested and is ready to be snapshotted for future reference, simply:
+
+  1. Make sure everything is merged onto `master`
+  
+  2. Checkout the `master` branch locally:
+  
+     `git checkout master`
+  
+  3. Pull the latest changes:
+  
+     `git pull`
+  
+  4. Produce the required tag:
+  
+     `./tag.sh`
+
+> **NOTE:** make sure that the expected `KEYCLOAK_VERSION` and `THEME_VERSION` are set within the [build.properties](../distribution/build.properties) file.

--- a/tag.sh
+++ b/tag.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+source distribution/build.properties
+
+if [[ -z "$KEYCLOAK_VERSION" || -z "$THEME_VERSION" ]]; then
+    echo "KEYCLOAK_VERSION and/or THEME_VERSION are missing."
+    echo "Please check the contents of distribution/build.properties".
+    exit 1
+fi
+
+TAG="keycloak-${KEYCLOAK_VERSION}_theme-${THEME_VERSION}"
+
+CURRENT_BRANCH=$(git branch | grep '*' | cut -d' ' -f 2)
+
+echo "Do you wish to tag and push the current branch '$CURRENT_BRANCH' as '$TAG' ?"
+select yn in "Yes" "No"; do
+    case $yn in
+    Yes)
+        git tag "$TAG" -m ""
+        git push origin "$TAG"
+        break
+        ;;
+    No)
+        exit
+        ;;
+    esac
+done


### PR DESCRIPTION
We don't plan to release any artifacts coming from this repository anymore, but it is still convenient to have tags as means to produce snapshots in time pertaining combinations of specific Keycloak + Alfresco Keycloak Theme combinations we tested and promote to our supported platforms.

The tagging of this repository is also convenient so we can reference potentially mutable docs/examples within the official Alfresco documentation by pointing to specific tags rather than the mutable master branch.