### PR TITLE
ACS-8676 Deal with upcoming GitHub Actions deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           curl -fsSL https://github.com/norwoodj/helm-docs/releases/download/v$HELM_DOCS_VERSION/helm-docs_${HELM_DOCS_VERSION}_$(uname)_x86_64.tar.gz | sudo tar xz -C /usr/local/bin/ helm-docs
           helm-docs --version
-      - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v3.8.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v7.0.0
 
   build:
     name: "Build"
@@ -39,8 +39,8 @@ jobs:
     needs: pre-commit
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v3.8.1
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v3.8.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_S3_PIPELINE_AMPS_ACCESS_KEY_ID  }}
@@ -66,8 +66,8 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v3.8.1
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v3.8.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_S3_PIPELINE_AMPS_ACCESS_KEY_ID  }}
@@ -88,7 +88,7 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v3.8.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_S3_PIPELINE_AMPS_ACCESS_KEY_ID  }}
@@ -119,26 +119,26 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v3.8.1
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v3.8.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_S3_PIPELINE_AMPS_ACCESS_KEY_ID  }}
           aws-secret-access-key: ${{ secrets.AWS_S3_PIPELINE_AMPS_SECRET_ACCESS_KEY  }}
           aws-region: ${{ env.AWS_REGION }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Login to Quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
       - name: Setup cluster
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@v3.8.1
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@v7.0.0
       - name: Create registries auth secret
         run: |
           kubectl create secret generic regcred \
@@ -238,8 +238,8 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v3.8.1
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v3.8.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_S3_PIPELINE_AMPS_ACCESS_KEY_ID  }}
@@ -265,7 +265,7 @@ jobs:
     needs: [test_linux, test_windows, test_helm, test_upgrade]
     if: always()
     steps:
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v3.8.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_S3_PIPELINE_AMPS_ACCESS_KEY_ID  }}


### PR DESCRIPTION
Migrate from `Node16` to `Node20`.
Bump `docker/login-action` to **v3**.
Additionally: upgrading the version to the latest for other actions from the `alfresco-build-tools`.