### PR TITLE
Mention that IDS has reached EoL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Alfresco Identity Service
 
 > ⚠ **WARNING**:
-> **Alfresco Identity Service is reaching End of Life.**
+> **Alfresco Identity Service has reached End of Life.**
 > Please refrain from using Alfresco Identity Service at this time and switch to raw Keycloak instead.
-> This branch now contains a set of tests and examples for raw Keycloak, whereas all Alfresco Identity Service development has been moved to [release/2.0.x](https://github.com/Alfresco/alfresco-identity-service/tree/release/2.0.x).
+> This branch now contains a set of tests and examples for vanilla Keycloak, whereas the, now unmaintained, Alfresco Identity Service development branch has been moved to [release/2.0.x](https://github.com/Alfresco/alfresco-identity-service/tree/release/2.0.x).
 
 *Keycloak* is a central component responsible for identity-related capabilities needed by other Alfresco software, such as managing users, groups, roles, profiles, and authentication. Currently it deals just with authentication. This project contains the open-source core of this service.
 


### PR DESCRIPTION
Keeping the link to the 2.0.x development branch for posterity, but otherwise we do not expect any further development there as IDS has officially reached EOL as of September 2024 as per https://connect.hyland.com/t5/alfresco-blog/alfresco-identity-service-end-of-life/ba-p/125226.